### PR TITLE
Init CMB2 at all times and not just for admins + register feather icons

### DIFF
--- a/Setup/Init.php
+++ b/Setup/Init.php
@@ -71,8 +71,9 @@ class Init {
 	protected function actions() {
 		add_action( 'admin_init', [ $this, 'update_install' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_scripts'], 5 );
-		add_action( 'wp_enqueue_scripts', [ $this, 'register_material_icons' ], 5 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'register_material_icons' ], 5 );
+		add_action( 'wp_enqueue_scripts', [ $this, 'register_icons' ], 5 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'register_icons' ], 5 );
+		add_action( 'script_loader_tag', [ $this, 'defer_scripts' ], 10, 3 );
 	}
 
 	/**
@@ -94,10 +95,31 @@ class Init {
 	}
 
 	/**
-         * Registers the material icons stylesheet
+  	 * Registers icons scripts and stylesheets to make them available to plugins that use ChurchPlugins core
 	 */
-	public function register_material_icons() {
+	public function register_icons() {
 		wp_register_style( 'material-icons', 'https://fonts.googleapis.com/css?family=Material+Icons|Material+Icons+Outlined' );
+		wp_register_script( 'feather-icons-external', 'https://cdnjs.cloudflare.com/ajax/libs/feather-icons/4.29.0/feather.min.js' );
+		wp_register_script( 'feather-icons', CHURCHPLUGINS_URL . 'assets/js/feather-icons.js', array( 'feather-icons-external' ) );
+	}
+
+
+	/**
+	 * Adds defer attribute to scripts
+	 */
+	public function defer_scripts( $tag, $handle, $src ) {
+		/**
+		 * Script handles whose resulting script tags will have a defer attribute
+		 * 
+		 * @param array $scripts list of script handles
+		 */
+		$scripts = apply_filters( 'cp_defer_scripts', array( 'feather-icons' ) );
+
+		if( in_array( $handle, $scripts ) ) {
+			return sprintf( '<script src="%1$s" defer type="text/javascript"></script>', $src );
+		}
+
+		return $tag;
 	}
 
 	/**

--- a/Setup/Init.php
+++ b/Setup/Init.php
@@ -71,8 +71,8 @@ class Init {
 	protected function actions() {
 		add_action( 'admin_init', [ $this, 'update_install' ] );
 		add_action( 'admin_enqueue_scripts', [ $this, 'register_scripts'], 5 );
-		add_action( 'wp_enqueue_scripts', [ $this, 'register_icons' ], 5 );
-		add_action( 'admin_enqueue_scripts', [ $this, 'register_icons' ], 5 );
+		add_action( 'wp_enqueue_scripts', [ $this, 'register_icons' ], -99 );
+		add_action( 'admin_enqueue_scripts', [ $this, 'register_icons' ], -99 );
 		add_action( 'script_loader_tag', [ $this, 'defer_scripts' ], 10, 3 );
 	}
 

--- a/Setup/PostTypes/PostType.php
+++ b/Setup/PostTypes/PostType.php
@@ -191,6 +191,7 @@ abstract class PostType {
 	 */
 	public function add_actions() {
 		add_action( 'cmb2_admin_init', [ $this, 'register_metaboxes' ] );
+		add_action( 'cmb2_init', [ $this, 'register_metaboxes' ] );
 
 		add_action( 'rest_cp_item_query', [ $this, 'rest_request_limit' ], 10, 1 );
 		add_action( "save_post", [ $this, 'maybe_save_post' ], 50 );

--- a/Setup/Taxonomies/Taxonomy.php
+++ b/Setup/Taxonomies/Taxonomy.php
@@ -235,6 +235,7 @@ abstract class Taxonomy {
 			'show_ui'               => false,
 			'show_admin_column'     => true,
 			'show_in_quick_edit'    => true,
+			'show_in_rest'          => true,
 			'query_var'             => true,
 			'rewrite'               => array( 'slug' => strtolower( $this->plural_label ) ),
 		);

--- a/assets/js/feather-icons.js
+++ b/assets/js/feather-icons.js
@@ -1,0 +1,1 @@
+feather.replace()


### PR DESCRIPTION
@tannerm there's often sensitive information in CMB2 fields, I'm not sure how much this exposes them. The reason behind it is because I needed the information in the rest API