### PR TITLE
Allow dynamic properties on Table class

### DIFF
--- a/CMB2/includes/types/CMB2_Type_Multi_Base.php
+++ b/CMB2/includes/types/CMB2_Type_Multi_Base.php
@@ -31,7 +31,7 @@ abstract class CMB2_Type_Multi_Base extends CMB2_Type_Base {
 	 * @param  int   $i    Iterator value
 	 * @return string       Gnerated list item html
 	 */
-	public function list_input( $args = array(), $i ) {
+	public function list_input( $args, $i ) {
 		$a = $this->parse_args( 'list_input', array(
 			'type'  => 'radio',
 			'class' => 'cmb2-option',

--- a/Integrations/CMB2/Init.php
+++ b/Integrations/CMB2/Init.php
@@ -137,7 +137,7 @@ class Init {
 	 * Return the list of options, with selected options at the top preserving their order. This also handles the
 	 * removal of selected options which no longer exist in the options array.
 	 */
-	public function get_pw_multiselect_options( $field_escaped_value = array(), $field_type_object ) {
+	public function get_pw_multiselect_options( $field_escaped_value, $field_type_object ) {
 		$options = (array) $field_type_object->field->options();
 
 		// If we have selected items, we need to preserve their order

--- a/Models/Table.php
+++ b/Models/Table.php
@@ -13,6 +13,7 @@ if ( ! defined( 'ABSPATH' ) ) exit;
  * @author Tanner Moushey
  * @since  1.0
 */
+#[\AllowDynamicProperties]
 abstract class Table {
 
 	/**


### PR DESCRIPTION
PHP 8 results in a warning when dynamic properties are created, PHP 9 will throw in a fatal error. Here is the code resulting in a warning.
https://github.com/Church-Plugins/ChurchPlugins/blob/72dc98d5b659b4c2a49450d7b778cb7ae7d90f78/Models/Table.php#L226-L228