### PR TITLE
Invalid cache key error

### DIFF
--- a/Models/Table.php
+++ b/Models/Table.php
@@ -506,7 +506,9 @@ abstract class Table {
 	public function delete_all_meta( $value, $column ) {
 		global $wpdb;
 
-		wp_cache_delete( $this->id, static::get_prop( 'cache_group' ) . '_meta' );
+		if ( $this->id ) {
+			wp_cache_delete( $this->id, static::get_prop( 'cache_group' ) . '_meta' );
+		}
 
 		return $wpdb->query( $wpdb->prepare( "DELETE FROM " . $this->meta_table_name . " WHERE `{$column}` = %s", $value ) );
 	}


### PR DESCRIPTION
When deleting meta, a new Speaker is being constructed without a reference to a post. This results in trying to delete a null cache key. This commit checks for an existing cache key before clearing the cache.

https://github.com/Church-Plugins/cp-library/blob/f0949199c9db20b21ea2db9fedda695a9a3cebaa/includes/Models/Item.php#L475-L477